### PR TITLE
Dockerfile para usar GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM python:3.8.12
+FROM nvcr.io/nvidia/cuda:12.8.0-runtime-ubuntu20.04
 LABEL org.opencontainers.image.source https://github.com/serengil/deepface
 
 # -----------------------------------
@@ -7,11 +7,19 @@ LABEL org.opencontainers.image.source https://github.com/serengil/deepface
 RUN mkdir -p /app && chown -R 1001:0 /app
 RUN mkdir /app/deepface
 
-
-
 # -----------------------------------
 # switch to application directory
 WORKDIR /app
+
+# install python
+RUN apt update -y && apt upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive  apt-get install -y wget build-essential checkinstall  libreadline-gplv2-dev  libncursesw5-dev  libssl-dev  libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev && \
+    cd /usr/src && \
+    wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz && \
+    tar xzf Python-3.8.12.tgz && \
+    cd Python-3.8.12 && \
+    ./configure --enable-optimizations && \
+    make altinstall
 
 # -----------------------------------
 # update image os
@@ -21,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     libsm6 \
     libxext6 \
     libhdf5-dev \
+    python-is-python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------
@@ -36,24 +45,24 @@ COPY ./entrypoint.sh /app/deepface/api/src/entrypoint.sh
 
 # -----------------------------------
 # if you plan to use a GPU, you should install the 'tensorflow-gpu' package
-# RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org tensorflow-gpu
+RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org tensorflow
 
 # if you plan to use face anti-spoofing, then activate this line
-# RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org torch==2.1.2
+# RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org torch==2.1.2
 # -----------------------------------
 # install deepface from pypi release (might be out-of-date)
-# RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org deepface
+# RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org deepface
 # -----------------------------------
 # install dependencies - deepface with these dependency versions is working
-RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org -r /app/requirements_local.txt
+RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org -r /app/requirements_local.txt
 # install deepface from source code (always up-to-date)
-RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org -e .
+RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org -e .
 
 # -----------------------------------
 # some packages are optional in deepface. activate if your task depends on one.
-# RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org cmake==3.24.1.1
-# RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org dlib==19.20.0
-# RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org lightgbm==2.3.1
+# RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org cmake==3.24.1.1
+# RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org dlib==19.20.0
+# RUN pip3.8 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org lightgbm==2.3.1
 
 # -----------------------------------
 # environment variables

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: deepface-cobli
+  name: deepface-cobli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deepface-cobli
+  template:
+    metadata:
+      labels:
+        app: deepface-cobli
+    spec:
+      containers:
+        - image: 'serengil/deepface'
+          ports:
+          - containerPort: 5000
+          name: deepface-cobli
+          resources:
+            requests:
+              memory: 5G
+              cpu: 500m
+            limits:
+              memory: 5G
+              cpu: 1500m
+      restartPolicy: Always

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deepface-cobli
+  labels:
+    app: deepface-cobli
+spec:
+  type: LoadBalancer
+  selector:
+      app: deepface-cobli
+  ports:
+  - port: 5000

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,11 @@
+locals {
+
+  tags = {
+    "finops.org/environment"     = "production",
+    "finops.org/expenses-nature" = "r-n-d",
+    "finops.org/service"         = "face-recognition",
+    "finops.org/feature"         = "face-recognition",
+    "cobli.co/iac-stack"         = "terraform"
+  }
+
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.48"
+    }
+  }
+  required_version = "< 1.7.0"
+}
+
+provider "aws" {
+  # Default provider
+  profile = "cobli-tech"
+  region  = "us-east-1"
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -1,0 +1,12 @@
+data "aws_route53_zone" "cobli_co" {
+  name         = "cobli.co."
+  private_zone = true
+}
+
+resource "aws_route53_record" "deepface_dev_endpoint" {
+  zone_id = data.aws_route53_zone.cobli_co.zone_id
+  name    = "deepface.dev.${data.aws_route53_zone.cobli_co.name}"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["a1b490ac2f3504b3f8fa8bb4387849f0-194051408.us-east-1.elb.amazonaws.com"]
+}


### PR DESCRIPTION
Como o Dockerfile precisa do código fonte do deepface, optei por fazer esse fork do projeto e editar o arquivo diretamente. Por isso movi os arquivos do deepface-deploy (https://github.com/Cobliteam/deepface-deploy) pra cá, para seguirmos com esse repositório apenas.