### PR TITLE
Adicionando configurações de log level

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: production
             - name: LOGGING_LEVEL_NAME
               value: WARNING
+            - name: DEEPFACE_LOG_LEVEL
+              value: {{ .Values.logLevel}}
             - name: DD_AGENT_HOST
               value: $(COBLERNETES_HOST_IP)
             - name: DD_TRACE_ENABLED

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,6 @@
 applicationName: &applicationName deepface
 namespace: &namespace coblicam
-appImageVersion: 1.0.1
+appImageVersion: 1.0.2
 
 repository: 911383825788.dkr.ecr.us-east-1.amazonaws.com/cobli-internal
 pullPolicy: IfNotPresent
@@ -31,6 +31,8 @@ appLivenessProbeTimeoutSeconds: 5
 appReadinessProbeTimeoutSeconds: 5
 appReadinessProbeFailureThreshold: 1
 appReadinessProbePeriodSeconds: 10
+
+logLevel: WARN
 
 uwsgi:
   processes: 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 echo "Starting the application..."
 exec "$@"
 
-gunicorn --workers=1 --timeout=7200 --bind=0.0.0.0:5000 --log-level=debug --access-logformat='%(h)s - - [%(t)s] "%(r)s" %(s)s %(b)s %(L)s' --access-logfile=- "app:create_app()"
+gunicorn --workers=1 --timeout=7200 --bind=0.0.0.0:5000 --log-level=warn --access-logformat='%(h)s - - [%(t)s] "%(r)s" %(s)s %(b)s %(L)s' --access-logfile=- "app:create_app()"


### PR DESCRIPTION
Esse PR reduz o log level para warn. A ideia é evitar spam de logs, que pode levar a incidentes de custos. Já subi a versão 1.0.2 pro ECR.