### PR TITLE
Ajustes para lidar com concorrência e reduzir tamanho da imagem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ COPY ./entrypoint.sh /app/deepface/api/src/entrypoint.sh
 # install dependencies - deepface with these dependency versions is working
 RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org -r /app/requirements_local.txt
 # install deepface from source code (always up-to-date)
+RUN pip install ultralytics==8.0.122 --no-deps
+RUN pip install torchvision>=0.8.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org -e .
 
 # -----------------------------------

--- a/deepface/api/src/api.py
+++ b/deepface/api/src/api.py
@@ -6,4 +6,4 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--port", type=int, default=5000, help="Port of serving api")
     args = parser.parse_args()
-    deepface_app.run(host="0.0.0.0", port=args.port)
+    deepface_app.run(host="0.0.0.0", port=args.port, threaded=True)

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,6 @@
 applicationName: &applicationName deepface
 namespace: &namespace coblicam
-appImageVersion: 1.0.2
+appImageVersion: 1.0.3
 
 repository: 911383825788.dkr.ecr.us-east-1.amazonaws.com/cobli-internal
 pullPolicy: IfNotPresent

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -8,8 +8,8 @@ appImageName: *applicationName
 name: *applicationName
 port: 5000
 
-replicas: 1
-minReplicas: 1
+replicas: 3
+minReplicas: 2
 maxReplicas: 6
 
 appCpuRequest: 1000m

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 echo "Starting the application..."
 exec "$@"
 
-gunicorn --workers=1 --timeout=7200 --bind=0.0.0.0:5000 --log-level=warn --access-logformat='%(h)s - - [%(t)s] "%(r)s" %(s)s %(b)s %(L)s' --access-logfile=- "app:create_app()"
+gunicorn --workers=1 --threads=5 --timeout=7200 --bind=0.0.0.0:5000 --log-level=warn --access-logformat='%(h)s - - [%(t)s] "%(r)s" %(s)s %(b)s %(L)s' --access-logfile=- "app:create_app()"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,10 @@ mtcnn>=0.1.0
 retina-face>=0.0.14
 fire>=0.4.0
 gunicorn>=20.1.0
-ultralytics>=8.0.122
+
+## Ultralytics deps
+matplotlib>=3.2.2
+psutil
+PyYAML>=5.3.1
+scipy>=1.4.1
+seaborn>=0.11.0

--- a/requirements_local
+++ b/requirements_local
@@ -4,4 +4,3 @@ Pillow==9.0.0
 opencv-python==4.9.0.80
 tensorflow==2.13.1
 keras==2.13.1
-ultralytics==8.0.122


### PR DESCRIPTION
O `gunicorn` lida com paralelismo de três formas: processos, threads e fake-threads. O ideal para operações intensivas em I/O são a última opção, mas isso exige usar uma interface chamada gevents na aplicação. Pra evitar essas alterações, segui por outro caminho, usando threads reais combinadas com a configuração do Flask para ser multi-thread. O número de threads segue a recomendação do gunicorn, de `2 * cpu + 1` (temos 2 mcores nessa aplicação).

Quanto às dependências: alterei a instalação do pacote da `ultralytics` para não trazer as dependências e mapeei manualmente as dependências deles no `requirements`, com exceção da `torchvision`, que era a biblioteca baixando módulos de GPU. Com a fonte que usa CPU, consegui reduzir o tamanho da imagem de 18 para 5GB.

A imagem comprimida no ECR ficou com pouco mais de 2GB.
![image](https://github.com/user-attachments/assets/4083b6af-62e0-4869-93ae-8601de259c04)
